### PR TITLE
Time offset

### DIFF
--- a/bookiesports/normalize.py
+++ b/bookiesports/normalize.py
@@ -1,7 +1,7 @@
 from . import BookieSports, datestring
 import logging
-import pytz
-
+from pytz import timezone
+from . import log
 
 class NotNormalizableException(Exception):
     pass
@@ -104,15 +104,15 @@ class IncidentsNormalizer(object):
 
         try:
             toReturn = start_date <= self._string_to_date(eventgroup["finish_date"], "to") and start_date >= self._string_to_date(eventgroup["start_date"], "from")
-        except: #Make it decent soon
-            print('-----dateTime offset naive failed')
+        except TypeError:
+            log.warning("datetime offset naive, failed")
 
         try:
             _timezone = timezone('UTC')
             start_date = _timezone.localize(start_date)
             toReturn = start_date <= self._string_to_date(eventgroup["finish_date"], "to") and start_date >= self._string_to_date(eventgroup["start_date"], "from")
-        except: #Make it decent soon
-            print('-------dateTime offset aware failed')
+        except TypeError: 
+            log.warning("datetime offset aware, failed")
         return toReturn
 
     def _get_eventgroup_identifier(self,

--- a/bookiesports/normalize.py
+++ b/bookiesports/normalize.py
@@ -101,10 +101,19 @@ class IncidentsNormalizer(object):
             return True
 
         start_date = datestring.string_to_date(start_date)
-        #convert the naive timezone to UTC
-        tz = pytz.timezone("UTC")
-        start_date = tz.localize(start_date)
-        return start_date <= self._string_to_date(eventgroup["finish_date"], "to") and start_date >= self._string_to_date(eventgroup["start_date"], "from")
+
+        try:
+            toReturn = start_date <= self._string_to_date(eventgroup["finish_date"], "to") and start_date >= self._string_to_date(eventgroup["start_date"], "from")
+        except: #Make it decent soon
+            print('-----dateTime offset naive failed')
+
+        try:
+            _timezone = timezone('UTC')
+            start_date = _timezone.localize(start_date)
+            toReturn = start_date <= self._string_to_date(eventgroup["finish_date"], "to") and start_date >= self._string_to_date(eventgroup["start_date"], "from")
+        except: #Make it decent soon
+            print('-------dateTime offset aware failed')
+        return toReturn
 
     def _get_eventgroup_identifier(self,
                                    sport_identifier,


### PR DESCRIPTION
A quick fix is done to solve the offset naive/aware timestamps comparision issue. The quick fix is to do the comparison with in both offset aware and naive formats and choose the successful one.
